### PR TITLE
Fix:NaviBar always handles back event

### DIFF
--- a/src/navibar.js
+++ b/src/navibar.js
@@ -221,8 +221,9 @@ export class InnerNaviBar extends React.PureComponent {
             } else {
                 this._clickButton('Right', rights[index - lefts.length], index - lefts.length);
             }
+            return true;
         }
-        return true;
+        return false;
     };
 
     _combineStyle = (key, innerStyle = undefined) => {


### PR DESCRIPTION
Let the back event continue to bubble when the NaviBar does not handle the back event